### PR TITLE
Fix empty cart total

### DIFF
--- a/js/Carrinho.js
+++ b/js/Carrinho.js
@@ -40,6 +40,6 @@ class Carrinho {
     }
 
     get carrinhoTotal() {
-        return this.itemsComprados.map(item => item.value).reduce((acc, current) => acc + current);
+        return this.itemsComprados.reduce((acc, item) => acc + item.value, 0);
     }
 }


### PR DESCRIPTION
## Summary
- ensure that `carrinhoTotal` returns 0 when no items were purchased

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f9177c30c832a933f630cd3f886ad